### PR TITLE
Make the post-deploy command configurable per-unit.

### DIFF
--- a/bin/deployer-checkout
+++ b/bin/deployer-checkout
@@ -14,9 +14,10 @@ main()
 
   # Validate config we use.
 
-  test -z "$GIT_WORK_TREE"  && barf "missing environment variable: GIT_WORK_TREE"
-  test -d "$GIT_WORK_TREE"  || barf "deploy directory missing: $GIT_WORK_TREE"
-  test -z "$GIT_DIR"        && barf "missing environment variable: GIT_DIR"
+  test -z "$GIT_WORK_TREE"    && barf "missing environment variable: GIT_WORK_TREE"
+  test -d "$GIT_WORK_TREE"    || barf "deploy directory missing: $GIT_WORK_TREE"
+  test -z "$GIT_DIR"          && barf "missing environment variable: GIT_DIR"
+  test -z "$DEPLOYER_COMMAND" && barf "missing environment variable: DEPLOYER_COMMAND"
 
   # If .git/ already exists, assume there's nothing to do.
 
@@ -42,7 +43,7 @@ main()
 
   (
     safe cd "$GIT_WORK_TREE"
-    safe make
+    safe "$DEPLOYER_COMMAND"
   )
 
   return $?

--- a/bin/deployer-manage
+++ b/bin/deployer-manage
@@ -1,15 +1,17 @@
 #!/bin/sh
 
-usage() { echo "usage: ${0##*/} [-x] [-k path/to/ssh/key] [-u user] [-g group] <unit> <git-url> [<branch>]"; }
+usage() { echo "usage: ${0##*/} [-x] [-k path/to/ssh/key] [-c command] [-u user] [-g group] <unit> <git-url> [<branch>]"; }
 
 main()
 {
   DEPLOYER_INPLACE=${DEPLOYER_INPLACE:-0}
+  DEPLOYER_COMMAND=${DEPLOYER_COMMAND:-make}
 
   while [ $# -gt 0 ]; do
     case "$1" in
          -x) DEPLOYER_INPLACE=1    ; shift ;;
          -k) DEPLOYER_SSH_KEY="$2" ; shift ; shift ;;
+         -c) DEPLOYER_COMMAND="$2" ; shift ; shift ;;
          -u) DEPLOYER_USER="$2"    ; shift ; shift ;;
          -g) DEPLOYER_GROUP="$2"   ; shift ; shift ;;
          -h) usage ; exit 0 ;;
@@ -19,6 +21,7 @@ main()
   done
   export DEPLOYER_INPLACE
   export DEPLOYER_SSH_KEY
+  export DEPLOYER_COMMAND
   export DEPLOYER_USER
   export DEPLOYER_GROUP
 
@@ -40,6 +43,7 @@ main()
   test -d "$DEPLOYER_QUEUE"       || barf "deploy root directory missing: $DEPLOYER_QUEUE"
   test -z "$DEPLOYER_UNITS_DIR"   && barf "missing environment variable: DEPLOYER_UNITS_DIR"
   test -d "$DEPLOYER_UNITS_DIR"   || barf "deploy data directory missing: $DEPLOYER_UNITS_DIR"
+  test -z "$DEPLOYER_COMMAND"     && barf "missing environment variable: DEPLOYER_COMMAND"
   test -z "$DEPLOYER_USER"        || DEPLOYER_GROUP=${DEPLOYER_GROUP:-`id -ng "$DEPLOYER_USER"`} || barf "gid error for $DEPLOYER_USER"
 
   # In privileged mode, some per-unit settings are required.
@@ -62,6 +66,7 @@ main()
   test -z "$DEPLOYER_SSH_KEY" || safe printf "%s" "$DEPLOYER_SSH_KEY" > "${DEPLOYER_UNITS_DIR}/${unit}/DEPLOYER_SSH_KEY"
   test -z "$DEPLOYER_USER"    || safe printf "%s" "$DEPLOYER_USER"    > "${DEPLOYER_UNITS_DIR}/${unit}/DEPLOYER_USER"
   test -z "$DEPLOYER_GROUP"   || safe printf "%s" "$DEPLOYER_GROUP"   > "${DEPLOYER_UNITS_DIR}/${unit}/DEPLOYER_GROUP"
+                                 safe printf "%s" "$DEPLOYER_COMMAND" > "${DEPLOYER_UNITS_DIR}/${unit}/DEPLOYER_COMMAND"
                                  safe printf "%s" "$unit"             > "${DEPLOYER_UNITS_DIR}/${unit}/DEPLOYER_UNIT"
 
   # Create a per-unit directory for incoming deployer job requests.

--- a/bin/deployer-queue
+++ b/bin/deployer-queue
@@ -5,5 +5,5 @@
 safe test -n "$DEPLOYER_QUEUE"
 safe cd "$DEPLOYER_QUEUE"
 safe deployer-stage-jobs
-exec fsq-run -v -Q new -D cur -A deployer-after-job . deployer-worker make
+exec fsq-run -v -Q new -D cur -A deployer-after-job . deployer-worker
 

--- a/bin/deployer-update
+++ b/bin/deployer-update
@@ -24,6 +24,7 @@ main()
 
   test -z "$DEPLOYER_DEPLOY_ROOT" && barf "missing environment variable: DEPLOYER_DEPLOY_ROOT"
   test -d "$DEPLOYER_DEPLOY_ROOT" || barf "deploy root directory missing: $DEPLOYER_DEPLOY_ROOT"
+  test -z "$DEPLOYER_COMMAND"     && barf "missing environment variable: DEPLOYER_COMMAND"
 
   # If we use an ssh key, run under ssh-agent, and load it from stdin.
 
@@ -98,12 +99,12 @@ main()
   ( safe cd "$GIT_WORK_TREE" && git stash )
   safe git checkout -B "$revision" origin/"$revision"
 
-  # Run the tail program (typically just `make`) to do post-update tasks.
+  # Run the DEPLOYER_COMMAND program (typically just `make`) to do post-update tasks.
   # Touch a file to indicate that a new deployment happened.
 
   (
     safe cd "$path_new"
-    test $# -eq 0 || safe "$@" 1>&2
+    test $# -eq 0 || safe "$DEPLOYER_COMMAND" 1>&2
     safe touch .deployed
   )
   rc="$?" ; if [ "$rc" -ne 0 ]; then return "$rc"; fi


### PR DESCRIPTION
Fixes #12. Defaults to `make`, the current hardcoded command. To disable the post-deploy command altogether (because the unit doesn't want or need a `Makefile`), use `deployer-manage -c true foo`.

Note: to avoid shell-escaping issues, `DEPLOYER_COMMAND` is interpreted as a program without arguments. So if you want to run eg `npm install && npm lint && npm test` as your post-deploy command, you'll have to put that in a script somewhere.
