### PR TITLE
Properly nest ssh-agent sessions when doing deploy operations.

### DIFF
--- a/bin/deployer-manage
+++ b/bin/deployer-manage
@@ -99,11 +99,11 @@ main()
       safe chown "${DEPLOYER_USER}:${DEPLOYER_GROUP}" "$GIT_WORK_TREE"
       {
         safe chown "${DEPLOYER_USER}:${DEPLOYER_GROUP}" /dev/stdin
-        safe setuidgid -s "$DEPLOYER_USER" env HOME=`eval echo ~$DEPLOYER_USER` deployer-checkout "$git_url" "$branch"
+        safe setuidgid -s "$DEPLOYER_USER" env -u SSH_AUTH_SOCK HOME=`eval echo ~$DEPLOYER_USER` deployer-checkout "$git_url" "$branch"
         safe chgrp -R "$DEPLOYER_GROUP" "$GIT_WORK_TREE"
       } < "${DEPLOYER_SSH_KEY:-/dev/null}"
     else
-      safe deployer-checkout "$git_url" "$branch" < "${DEPLOYER_SSH_KEY:-/dev/null}"
+      safe env -u SSH_AUTH_SOCK deployer-checkout "$git_url" "$branch" < "${DEPLOYER_SSH_KEY:-/dev/null}"
     fi
   done
 

--- a/bin/deployer-perform
+++ b/bin/deployer-perform
@@ -50,10 +50,10 @@ main()
   if [ `id -u` -eq 0 ]; then
     {
       safe chown "${DEPLOYER_USER}:${DEPLOYER_GROUP}" /dev/stdin
-      setuidgid -s "$DEPLOYER_USER" env HOME=`eval echo ~$DEPLOYER_USER` deployer-update "$unit" "$revision" "$@" || exit $?
+      setuidgid -s "$DEPLOYER_USER" env -u SSH_AUTH_SOCK HOME=`eval echo ~$DEPLOYER_USER` deployer-update "$unit" "$revision" "$@" || exit $?
     } < "${DEPLOYER_SSH_KEY:-/dev/null}" || exit $?
   else
-    deployer-update "$unit" "$revision" "$@" < "${DEPLOYER_SSH_KEY:-/dev/null}" || exit $?
+    env -u SSH_AUTH_SOCK deployer-update "$unit" "$revision" "$@" < "${DEPLOYER_SSH_KEY:-/dev/null}" || exit $?
   fi
 
   # Success. Unless we're in-place, swap active & inactive checkouts via the symlink.


### PR DESCRIPTION
This fixes a bug where `deployer-checkout` and `deployer-update` will reuse an existing ssh-agent session instead of creating a new dedicated ssh-agent to load a deploy key into.
