### PR TITLE
Truncate base64-encoded subject line pieces to 76 chars. 

### DIFF
--- a/bin/deployer-mailer-worker
+++ b/bin/deployer-mailer-worker
@@ -60,9 +60,9 @@ EORESULT
     * ) status_text="FAIL" ; status_char='\342\235\214' ;;
   esac
 
-  subject1_encoded=`printf "[deployer] $status_char %s" "$unit/$branch" | base64`
-  subject2_encoded=`printf " (%s) -- %s" "$status_text" "$hash" | base64`
-  subject3_encoded=`printf " -- %s" "$message" | base64`
+  subject1_encoded=`printf "[deployer] $status_char %s" "$unit/$branch" | head -c 54 | base64`
+  subject2_encoded=`printf " (%s) -- %s" "$status_text" "$hash" | head -c 54 | base64`
+  subject3_encoded=`printf " -- %s" "$message" | head -c 54 | base64`
 
   # Replay full job output as email body.
   safe rewind


### PR DESCRIPTION
Any string longer than 54 characters can produce a base64 encoding longer than 72 characters. When this happens, `base64(1)` wraps to the next line. Even if it didn't, non-continued subject lines longer than 72 characters are problematic for some mail handlers. So, truncate the 3 subject line continuation pieces to 54 characters each (72 base64 encoded) and that should sidestep most issues. Note that truncation really should be sensitive to multibyte characters (eg `utf-8` sequences) and it isn't here. But who puts `utf-8` characters in long git commit subject lines anyway?