### PR TITLE
Install services, users, groups, and runtime directories in debian package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,6 @@ install :
 	find $(CURDIR)/bin -type f -print0 | xargs -0 -n1 -I@ install -m 0755 @ $(DESTDIR)$(PREFIX)/bin
 	install -d $(DESTDIR)/etc
 	install -m 0640 $(CURDIR)/etc/deployer.example.conf $(DESTDIR)/etc/deployer.conf
+	install -d $(DESTDIR)/etc/service
+	( cd $(CURDIR)/etc/service && tar cf - . ) | ( cd $(DESTDIR)/etc/service && tar xvf - . )
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -e
+
+# TODO source /etc/deployer.conf to get configured locations.
+
+# Create privsep users.
+
+getent passwd bouncer >/dev/null ||
+  useradd bouncer -U -c "Bouncer Service" -d /nonexistent -s /usr/sbin/nologin
+
+getent passwd deployer-mailer >/dev/null ||
+  useradd deployer-mailer -U -c "Deployer Mailer Service" -d /nonexistent -s /usr/sbin/nologin
+
+getent passwd deployer-log >/dev/null ||
+  useradd deployer-log -U -c "Deployer Logger" -d /nonexistent -s /usr/sbin/nologin
+
+# Create groups.
+# TODO emit informational message about adding users to these groups.
+
+getent group deployers >/dev/null ||
+  groupadd deployers
+
+getent group svc-deployer >/dev/null ||
+  groupadd svc-deployer
+
+getent group svc-deployer-mailer >/dev/null ||
+  groupadd svc-deployer-mailer
+
+getent group svc-bouncer >/dev/null ||
+  groupadd svc-bouncer
+
+# Create state directories.
+
+install -d -m 0755 -u root            -g root            /var/lib/deployer
+install -d -m 0755 -u deployer-mailer -g deployer-mailer /var/lib/deployer-mailer
+install -d -m 0755 -u bouncer         -g bouncer         /var/lib/bouncer
+
+# Create trigger directories.
+
+install -d -m 0755 -u root            -g root            /var/trigger
+install -d -m 0755 -u root            -g root            /var/trigger/deployer
+install -d -m 0755 -u deployer-mailer -g deployer-mailer /var/trigger/deployer-mailer
+install -d -m 0755 -u bouncer         -g bouncer         /var/trigger/bouncer
+
+# Create lock file directories.
+
+install -d -m 0755 -u root -g root /var/locks/deployer/unit
+
+# Create filesystem queue directories.
+
+install -d -m 0755 -u root            -g root            /var/queue
+install -d -m 0755 -u root            -g root            /var/queue/deployer
+install -d -m 3775 -u root            -g deployers       /var/queue/deployer/tmp
+install -d -m 0755 -u root            -g root            /var/queue/deployer/req
+install -d -m 0755 -u root            -g root            /var/queue/deployer/new
+install -d -m 0755 -u root            -g root            /var/queue/deployer/cur
+install -d -m 0755 -u root            -g root            /var/queue/deployer/fail
+install -d -m 0755 -u deployer-mailer -g deployer-mailer /var/queue/deployer-mailer
+install -d -m 0755 -u deployer-mailer -g deployer-mailer /var/queue/deployer-mailer/tmp
+install -d -m 0755 -u deployer-mailer -g deployer-mailer /var/queue/deployer-mailer/new
+install -d -m 0755 -u deployer-mailer -g deployer-mailer /var/queue/deployer-mailer/cur
+install -d -m 0755 -u deployer-mailer -g deployer-mailer /var/queue/deployer-mailer/fail
+
+# Create daemontools state directories.
+
+install -d -m 0755 -u root -g root /var/lib/supervise/deployer
+install -d -m 0755 -u root -g root /var/lib/supervise/deployer.log
+install -d -m 0755 -u root -g root /var/lib/supervise/deployer-mailer
+install -d -m 0755 -u root -g root /var/lib/supervise/deployer-mailer.log
+install -d -m 0755 -u root -g root /var/lib/supervise/bouncer
+install -d -m 0755 -u root -g root /var/lib/supervise/bouncer.log
+
+# Create log file directories.
+
+install -d -m 0775 -u root -g deployer-log /var/log/deployer
+install -d -m 0775 -u root -g deployer-log /var/log/deployer-mailer
+install -d -m 0775 -u root -g deployer-log /var/log/bouncer
+
+# TODO install and enable the service using `/usr/sbin/update-service`?
+

--- a/etc/deployer.example.conf
+++ b/etc/deployer.example.conf
@@ -8,22 +8,25 @@ PREFIX=""
 export DEPLOYER_CONFIG="$PREFIX/etc/deployer.conf"
 
 # Full path to the directory where settings for each managed unit are stored.
-export DEPLOYER_UNITS_DIR="$PREFIX/var/lib/deployer/units"
+export DEPLOYER_UNITS_DIR="$PREFIX/etc/deployer/units"
 
 # Full path to the deployer filesystem queue.
-export DEPLOYER_QUEUE="$PREFIX/var/lib/deployer/queue"
+export DEPLOYER_QUEUE="$PREFIX/var/queue/deployer"
 
 # Full path to the deployer service trigger, for trigger-listen / trigger-pull.
-export DEPLOYER_TRIGGER="$PREFIX/var/lib/deployer/trigger.fifo"
+export DEPLOYER_TRIGGER="$PREFIX/var/trigger/deployer/trigger.fifo"
+
+# Full path to the bouncer service trigger, for trigger-listen / trigger-pull.
+export DEPLOYER_BOUNCER_TRIGGER="$PREFIX/var/trigger/bouncer/trigger.fifo"
 
 # Full path to lockfile that protects the queue's /req/* -> /new/ job staging operation.
-export DEPLOYER_STAGE_LOCK="$PREFIX/var/lib/deployer/lock/stage.lock"
+export DEPLOYER_STAGE_LOCK="$PREFIX/var/locks/deployer/stage.lock"
 
 # Full path to the directory of deployer per-unit lockfiles.
-export DEPLOYER_UNIT_LOCK_DIR="$PREFIX/var/lib/deployer/lock/unit"
+export DEPLOYER_UNIT_LOCK_DIR="$PREFIX/var/locks/deployer/unit"
 
 # Full path to the directory of bounce files used by deployer-bouncer.
-export DEPLOYER_BOUNCED_DIR="$PREFIX/var/lib/deployer/bounced"
+export DEPLOYER_BOUNCED_DIR="$PREFIX/var/lib/bouncer"
 
 # Full path to the directory where all managed deployments live.
 export DEPLOYER_DEPLOY_ROOT="$PREFIX/home/deploys"
@@ -40,11 +43,11 @@ export DEPLOYER_RETRY_DELAY=1
 
 
 # Full path to the deployer-mailer filesystem queue.
-# export DEPLOYER_MAILER_QUEUE="$PREFIX/var/lib/deployer-mailer/queue"
+# export DEPLOYER_MAILER_QUEUE="$PREFIX/var/queue/deployer-mailer"
 export DEPLOYER_MAILER_QUEUE=""
 
 # Full path to the deployer-mailer service trigger, for trigger-listen / trigger-pull.
-# export DEPLOYER_MAILER_TRIGGER="$PREFIX/var/lib/deployer-mailer/trigger.fifo"
+# export DEPLOYER_MAILER_TRIGGER="$PREFIX/var/trigger/deployer-mailer/trigger.fifo"
 export DEPLOYER_MAILER_TRIGGER=""
 
 # From: line for deployer job emails.

--- a/etc/service/bouncer/bounce
+++ b/etc/service/bouncer/bounce
@@ -1,0 +1,3 @@
+#!/bin/sh
+# nothing special to do here
+true

--- a/etc/service/bouncer/log/main
+++ b/etc/service/bouncer/log/main
@@ -1,0 +1,1 @@
+/var/log/bouncer

--- a/etc/service/bouncer/log/run
+++ b/etc/service/bouncer/log/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+test `id -u` -gt 0 || exec setuidgid -s deployer-log "$0" "$@"
+exec multilog t '+*' s1048576 n64 ./main

--- a/etc/service/bouncer/log/supervise
+++ b/etc/service/bouncer/log/supervise
@@ -1,0 +1,1 @@
+/var/lib/supervise/bouncer.log

--- a/etc/service/bouncer/root
+++ b/etc/service/bouncer/root
@@ -1,0 +1,1 @@
+/var/lib/bouncer

--- a/etc/service/bouncer/run
+++ b/etc/service/bouncer/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+exec 2>&1
+test `id -u` -gt 0 || exec setuidgid -s bouncer env HOME=`eval echo ~bouncer` "$0" "$@"
+cd ./root
+export DEPLOYER_CONFIG="/etc/deployer.conf"
+. "$DEPLOYER_CONFIG"
+exec trigger-listen -v -c 1 "$DEPLOYER_BOUNCER_TRIGGER" deployer-bouncer /service

--- a/etc/service/bouncer/start
+++ b/etc/service/bouncer/start
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec enable-svcgroup

--- a/etc/service/bouncer/supervise
+++ b/etc/service/bouncer/supervise
@@ -1,0 +1,1 @@
+/var/lib/supervise/bouncer

--- a/etc/service/bouncer/trigger.fifo
+++ b/etc/service/bouncer/trigger.fifo
@@ -1,0 +1,1 @@
+/var/trigger/bouncer/trigger.fifo

--- a/etc/service/deployer-mailer/bounce
+++ b/etc/service/deployer-mailer/bounce
@@ -1,0 +1,3 @@
+#!/bin/sh
+# nothing special to do here
+true

--- a/etc/service/deployer-mailer/log/main
+++ b/etc/service/deployer-mailer/log/main
@@ -1,0 +1,1 @@
+/var/log/deployer-mailer

--- a/etc/service/deployer-mailer/log/run
+++ b/etc/service/deployer-mailer/log/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+test `id -u` -gt 0 || exec setuidgid deployer-log "$0" "$@"
+exec multilog t '+*' s1048576 n64 ./main

--- a/etc/service/deployer-mailer/log/supervise
+++ b/etc/service/deployer-mailer/log/supervise
@@ -1,0 +1,1 @@
+/var/lib/supervise/deployer-mailer.log

--- a/etc/service/deployer-mailer/root
+++ b/etc/service/deployer-mailer/root
@@ -1,0 +1,1 @@
+/var/lib/deployer-mailer

--- a/etc/service/deployer-mailer/run
+++ b/etc/service/deployer-mailer/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+exec 2>&1
+test `id -u` -gt 0 || exec setuidgid -s deployer-mailer env HOME=`eval echo ~deployer-mailer` "$0" "$@"
+cd ./root
+export DEPLOYER_CONFIG="/etc/deployer.conf"
+exec deployer-mailer-service

--- a/etc/service/deployer-mailer/start
+++ b/etc/service/deployer-mailer/start
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec enable-svcgroup

--- a/etc/service/deployer-mailer/supervise
+++ b/etc/service/deployer-mailer/supervise
@@ -1,0 +1,1 @@
+/var/lib/supervise/deployer-mailer

--- a/etc/service/deployer-mailer/trigger.fifo
+++ b/etc/service/deployer-mailer/trigger.fifo
@@ -1,0 +1,1 @@
+/var/trigger/deployer-mailer/trigger.fifo

--- a/etc/service/deployer/bounce
+++ b/etc/service/deployer/bounce
@@ -1,0 +1,3 @@
+#!/bin/sh
+# nothing special to do here
+true

--- a/etc/service/deployer/log/main
+++ b/etc/service/deployer/log/main
@@ -1,0 +1,1 @@
+/var/log/deployer

--- a/etc/service/deployer/log/run
+++ b/etc/service/deployer/log/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+test `id -u` -gt 0 || exec setuidgid -s deployer-log "$0" "$@"
+exec multilog t '+*' s1048576 n64 ./main

--- a/etc/service/deployer/log/supervise
+++ b/etc/service/deployer/log/supervise
@@ -1,0 +1,1 @@
+/var/lib/supervise/deployer.log

--- a/etc/service/deployer/root
+++ b/etc/service/deployer/root
@@ -1,0 +1,1 @@
+/var/lib/deployer

--- a/etc/service/deployer/run
+++ b/etc/service/deployer/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+exec 2>&1
+umask 0002
+cd ./root
+export DEPLOYER_CONFIG="/etc/deployer.conf"
+exec deployer-service

--- a/etc/service/deployer/start
+++ b/etc/service/deployer/start
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec enable-svcgroup

--- a/etc/service/deployer/supervise
+++ b/etc/service/deployer/supervise
@@ -1,0 +1,1 @@
+/var/lib/supervise/deployer

--- a/etc/service/deployer/trigger.fifo
+++ b/etc/service/deployer/trigger.fifo
@@ -1,0 +1,1 @@
+/var/trigger/deployer/trigger.fifo


### PR DESCRIPTION
Towards a debian deployer package that works out of the box.

- [ ] Respect `/etc/deployer.conf` locations in the `postinst` script.
- [ ] Automatically start and install the services?
- [ ] Add a `postrm` script that undoes some of the `postinst` actions?
- [ ] Test it.
- [ ] Bump version.