### PR TITLE
Add basic cluster support.

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -51,6 +51,7 @@ main()
     fi
     for hostqueue in "$DEPLOYER_HOSTQUEUES_DIR"/*; do
       test -n "$ourhostid" -a "${hostqueue##*/}" = "$ourhostid" && continue
+      test -d "$hostqueue/tmp" || continue
       safe job_enqueue "$hostqueue" "$unit" "$jobname"
     done
   fi

--- a/bin/deploy
+++ b/bin/deploy
@@ -25,8 +25,6 @@ main()
   safe . deployer-autoconfigure
 
   test -z "$DEPLOYER_UNITS_DIR" && barf "missing environment variable: DEPLOYER_UNITS_DIR"
-  test -z "$DEPLOYER_QUEUE"     && barf "missing environment variable: DEPLOYER_QUEUE"
-  test -z "$DEPLOYER_TRIGGER"   && barf "missing environment variable: DEPLOYER_TRIGGER"
 
   # Verify that the unit is actually a managed deployment.
 
@@ -39,16 +37,30 @@ main()
   jobrandom=`safe hexdump -n 4 -e '1/4 "%08x"' < /dev/urandom` || exit $?
   jobname="${revision_escaped}.${jobdatetime}.${jobrandom}"
 
-  # Enqueue a new job file.
+  # Enqueue deployer job files into each queue.
 
-  safe touch     "$DEPLOYER_QUEUE/tmp/$jobname"
-  safe chmod g+w "$DEPLOYER_QUEUE/tmp/$jobname"
-  safe mv        "$DEPLOYER_QUEUE/tmp/$jobname" "$DEPLOYER_QUEUE/req/$unit/$jobname"
+  if [ -d "$DEPLOYER_HOSTQUEUES_DIR" ]; then
+    for hostqueue in "$DEPLOYER_HOSTQUEUES_DIR"/*; do
+      safe job_enqueue "$hostqueue" "$unit" "$jobname"
+      # TODO pull trigger if this is our own host queue
+    done
+  else
+    test -z "$DEPLOYER_QUEUE"   && barf "missing environment variable: DEPLOYER_QUEUE"
+    test -z "$DEPLOYER_TRIGGER" && barf "missing environment variable: DEPLOYER_TRIGGER"
+    safe job_enqueue "$DEPLOYER_QUEUE" "$unit" "$jobname" "$DEPLOYER_TRIGGER"
+  fi
+}
 
-  log 2 "enqueued new deployer job: ${unit}.${jobname}"
-
-  [ -n "$DEPLOYER_TRIGGER" ] && trigger-pull "$DEPLOYER_TRIGGER" >/dev/null 2>&1
-
+job_enqueue() {
+  queue="$1"   ; shift
+  unit="$1"    ; shift
+  jobname="$1" ; shift
+  trigger="$1" ; shift
+  safe touch     "$queue/tmp/$jobname"
+  safe chmod g+w "$queue/tmp/$jobname"
+  safe mv        "$queue/tmp/$jobname" "$queue/req/$unit/$jobname"
+  log 2 "enqueued new deployer job ${unit}.${jobname} into $queue"
+  [ -n "$trigger" ] && trigger-pull "$trigger" >/dev/null 2>&1
   return 0
 }
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -25,6 +25,8 @@ main()
   safe . deployer-autoconfigure
 
   test -z "$DEPLOYER_UNITS_DIR" && barf "missing environment variable: DEPLOYER_UNITS_DIR"
+  test -z "$DEPLOYER_QUEUE"     && barf "missing environment variable: DEPLOYER_QUEUE"
+  test -z "$DEPLOYER_TRIGGER"   && barf "missing environment variable: DEPLOYER_TRIGGER"
 
   # Verify that the unit is actually a managed deployment.
 
@@ -37,17 +39,20 @@ main()
   jobrandom=`safe hexdump -n 4 -e '1/4 "%08x"' < /dev/urandom` || exit $?
   jobname="${revision_escaped}.${jobdatetime}.${jobrandom}"
 
-  # Enqueue deployer job files into each queue.
+  # First enqueue a deployer job file into our local queue.
+
+  safe job_enqueue "$DEPLOYER_QUEUE" "$unit" "$jobname" "$DEPLOYER_TRIGGER"
+
+  # Then enqueue deployer job files into queues for other hosts.
 
   if [ -d "$DEPLOYER_HOSTQUEUES_DIR" ]; then
+    if [ -f "$DEPLOYER_STATE_DIR/hostid" ]; then
+      ourhostid=`safe cat "$DEPLOYER_STATE_DIR/hostid"` || exit $?
+    fi
     for hostqueue in "$DEPLOYER_HOSTQUEUES_DIR"/*; do
+      test -n "$ourhostid" -a "${hostqueue##*/}" = "$ourhostid" && continue
       safe job_enqueue "$hostqueue" "$unit" "$jobname"
-      # TODO pull trigger if this is our own host queue
     done
-  else
-    test -z "$DEPLOYER_QUEUE"   && barf "missing environment variable: DEPLOYER_QUEUE"
-    test -z "$DEPLOYER_TRIGGER" && barf "missing environment variable: DEPLOYER_TRIGGER"
-    safe job_enqueue "$DEPLOYER_QUEUE" "$unit" "$jobname" "$DEPLOYER_TRIGGER"
   fi
 }
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -60,7 +60,7 @@ job_enqueue() {
   queue="$1"   ; shift
   unit="$1"    ; shift
   jobname="$1" ; shift
-  trigger="$1" ; shift
+  trigger="$1"
   safe touch     "$queue/tmp/$jobname"
   safe chmod g+w "$queue/tmp/$jobname"
   safe mv        "$queue/tmp/$jobname" "$queue/req/$unit/$jobname"

--- a/bin/deployer-service
+++ b/bin/deployer-service
@@ -7,6 +7,6 @@ safe . "$DEPLOYER_CONFIG"
 safe test "$DEPLOYER_CONCURRENCY" -ge 0
 safe test -n "$DEPLOYER_TRIGGER"
 
-exec trigger-listen -v -1 -c "$DEPLOYER_CONCURRENCY" "$DEPLOYER_TRIGGER" \
+exec trigger-listen -v -1 -c "$DEPLOYER_CONCURRENCY" -t "${DEPLOYER_RESCAN_INTERVAL:-4294967295}" "$DEPLOYER_TRIGGER" \
   sh -e -c '. "$0" ; cd "$DEPLOYER_QUEUE" ; exec "$@"' "$DEPLOYER_CONFIG" deployer-queue
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deployer (1:0.2.0) trusty; urgency=low
+
+  * Add cluster support.
+
+ -- Alan Grow <alangrow@gmail.com>  Thu, 31 Aug 2017 17:54:05 -0600
+
 deployer (1:0.1.5) trusty; urgency=low
 
   * Fix bug where bouncer would skip the initial bounces.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deployer (1:0.2.1) trusty; urgency=low
+
+  * Fix issues with hostqueues.
+
+ -- Alan Grow <alangrow@gmail.com>  Thu, 31 Aug 2017 19:05:29 -0600
+
 deployer (1:0.2.0) trusty; urgency=low
 
   * Add cluster support.

--- a/etc/deployer.example.conf
+++ b/etc/deployer.example.conf
@@ -25,6 +25,12 @@ export DEPLOYER_STAGE_LOCK="$PREFIX/var/locks/deployer/stage.lock"
 # Full path to the directory of deployer per-unit lockfiles.
 export DEPLOYER_UNIT_LOCK_DIR="$PREFIX/var/locks/deployer/unit"
 
+# Full path to the state directory for deployer.
+export DEPLOYER_STATE_DIR="$PREFIX/var/lib/deployer"
+
+# Full path to the per-host deployer queues, if running in a cluster.
+export DEPLOYER_HOSTQUEUES_DIR="$DEPLOYER_STATE_DIR/hostqueues"
+
 # Full path to the directory of bounce files used by deployer-bouncer.
 export DEPLOYER_BOUNCED_DIR="$PREFIX/var/lib/bouncer"
 

--- a/etc/deployer.example.conf
+++ b/etc/deployer.example.conf
@@ -13,6 +13,9 @@ export DEPLOYER_UNITS_DIR="$PREFIX/etc/deployer/units"
 # Full path to the deployer filesystem queue.
 export DEPLOYER_QUEUE="$PREFIX/var/queue/deployer"
 
+# How often to rescan the deployer queue. Empty string means don't rescan.
+export DEPLOYER_RESCAN_INTERVAL=""
+
 # Full path to the deployer service trigger, for trigger-listen / trigger-pull.
 export DEPLOYER_TRIGGER="$PREFIX/var/trigger/deployer/trigger.fifo"
 


### PR DESCRIPTION
If a "host queues" directory is present, `deploy` now also enqueues a separate job into each queue underneath it. To arrange for cluster-wide deployments, just ensure that each host's queue lives on a common NFS share and `DEPLOYER_HOSTQUEUES_DIR` points to their parent directory. A deployment on any single host will fan out to all hosts.

The only catch is that fifos don't work across NFS clients, so other hosts' deployment triggers can't be pulled after enqueueing their jobs. So this change also introduces optional queue polling via `DEPLOYER_RESCAN_INTERVAL`.