### PR TITLE
Fix continual debian package upgrade issue.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deployer (1:0.2.1-2) trusty; urgency=low
+
+  * Fix debian package control field that caused apt-get upgrade reinstallation.
+
+ -- Alan Grow <alangrow@gmail.com>  Thu, 31 Aug 2017 19:05:29 -0600
+
 deployer (1:0.2.1) trusty; urgency=low
 
   * Fix issues with hostqueues.

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Vcs-Browser: https://github.com/endcrawl/deployer
 Package: deployer
 Section: devel
 Architecture: all
-Depends: daemontools (>= 1:1.13), trigger (>= 0:0.68), fsq-run (>= 1:0.1.0), daemontools-extra (>= 1:0.1.0)
+Depends: daemontools (>= 1:1.13), trigger (>= 0.68), fsq-run (>= 1:0.1.0), daemontools-extra (>= 1:0.1.0)
 Description: Automated zero-downtime deployments.
 


### PR DESCRIPTION
The problem: `apt-get upgrade` was always upgrading deployer, even though it was the latest version. This turned out to be caused by normalization of the package control information. The package had this line:

```
Depends: daemontools (>= 1:1.13), trigger (>= 0:0.68), fsq-run (>= 1:0.1.0), daemontools-extra (>= 1:0.1.0)
```

But once the package was installed, the `/var/lib/dpkg/status` file had this control field:

```
Depends: daemontools (>= 1:1.13), trigger (>= 0.68), fsq-run (>= 1:0.1.0), daemontools-extra (>= 1:0.1.0)
```

This was enough to convince `apt-get upgrade` that the package was different remotely and (always) needed upgrading.